### PR TITLE
Ecr lifecycle policy

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -29,18 +29,17 @@ jobs:
         uses: int128/create-ecr-repository-action@v1
         with:
           repository: ${{ github.event.repository.name  }}  
-          lifecycle-policy: "{\"rules\":[{\"rulePriority\":1,\"description\":\"Expire untagged images\",\"selection\":{\"tagStatus\":\"untagged\",\"countType\":\"sinceImagePushed\",\"countUnit\":\"days\",\"countNumber\":1},\"action\":{\"type\":\"expire\"}},{\"rulePriority\":2,\"description\":\"Expire old images with default tag\",\"selection\":{\"tagStatus\":\"tagged\",\"tagPrefixList\":[\"master-\"],\"countType\":\"imageCountMoreThan\",\"countNumber\":50},\"action\":{\"type\":\"expire\"}}]}"
 
       - name: Update ECR Repo Policy
         id: update-ecr-repo-policy
         run: |
           aws ecr set-repository-policy --policy-text ${{ secrets.ECR_REPO_POLICY }}  --repository-name ${{ github.event.repository.name  }}
       
-      # - name: Update ECR Lifecycle Policy
-      #   id: update-ecr-lifecycle-policy
-      #   run: |
-      #     aws ecr put-lifecycle-policy --repository-name podinfo --lifecycle-policy-text \
-      #       "{\"rules\":[{\"rulePriority\":1,\"description\":\"Expire untagged images\",\"selection\":{\"tagStatus\":\"untagged\",\"countType\":\"sinceImagePushed\",\"countUnit\":\"days\",\"countNumber\":1},\"action\":{\"type\":\"expire\"}},{\"rulePriority\":2,\"description\":\"Expire old images with default tag\",\"selection\":{\"tagStatus\":\"tagged\",\"tagPrefixList\":[\"master-\"],\"countType\":\"imageCountMoreThan\",\"countNumber\":50},\"action\":{\"type\":\"expire\"}}]}",
+      - name: Update ECR Lifecycle Policy
+        id: update-ecr-lifecycle-policy
+        run: |
+          aws ecr put-lifecycle-policy --repository-name podinfo --lifecycle-policy-text \
+            "{\"rules\":[{\"rulePriority\":1,\"description\":\"Expire untagged images\",\"selection\":{\"tagStatus\":\"untagged\",\"countType\":\"sinceImagePushed\",\"countUnit\":\"days\",\"countNumber\":1},\"action\":{\"type\":\"expire\"}},{\"rulePriority\":2,\"description\":\"Expire old images with default tag\",\"selection\":{\"tagStatus\":\"tagged\",\"tagPrefixList\":[\"master-\"],\"countType\":\"imageCountMoreThan\",\"countNumber\":50},\"action\":{\"type\":\"expire\"}}]}",
 
 
       - name: Login to Amazon ECR

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -28,13 +28,21 @@ jobs:
         id: create-ecr-repo
         uses: int128/create-ecr-repository-action@v1
         with:
-          repository: ${{ github.event.repository.name  }}    
+          repository: ${{ github.event.repository.name  }}  
+          lifecycle-policy: "{\"rules\":[{\"rulePriority\":1,\"description\":\"Expire untagged images\",\"selection\":{\"tagStatus\":\"untagged\",\"countType\":\"sinceImagePushed\",\"countUnit\":\"days\",\"countNumber\":1},\"action\":{\"type\":\"expire\"}},{\"rulePriority\":2,\"description\":\"Expire old images with default tag\",\"selection\":{\"tagStatus\":\"tagged\",\"tagPrefixList\":[\"master-\"],\"countType\":\"imageCountMoreThan\",\"countNumber\":50},\"action\":{\"type\":\"expire\"}}]}"
 
       - name: Update ECR Repo Policy
-        id: update-ecr-policy
+        id: update-ecr-repo-policy
         run: |
           aws ecr set-repository-policy --policy-text ${{ secrets.ECR_REPO_POLICY }}  --repository-name ${{ github.event.repository.name  }}
       
+      # - name: Update ECR Lifecycle Policy
+      #   id: update-ecr-lifecycle-policy
+      #   run: |
+      #     aws ecr put-lifecycle-policy --repository-name podinfo --lifecycle-policy-text \
+      #       "{\"rules\":[{\"rulePriority\":1,\"description\":\"Expire untagged images\",\"selection\":{\"tagStatus\":\"untagged\",\"countType\":\"sinceImagePushed\",\"countUnit\":\"days\",\"countNumber\":1},\"action\":{\"type\":\"expire\"}},{\"rulePriority\":2,\"description\":\"Expire old images with default tag\",\"selection\":{\"tagStatus\":\"tagged\",\"tagPrefixList\":[\"master-\"],\"countType\":\"imageCountMoreThan\",\"countNumber\":50},\"action\":{\"type\":\"expire\"}}]}",
+
+
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1


### PR DESCRIPTION
Added below lifecycle policy to ECR for auto cleanup and clutter free repo.

```json
{
  "rules": [
    {
      "rulePriority": 1,
      "description": "Expire untagged images",
      "selection": {
        "tagStatus": "untagged",
        "countType": "sinceImagePushed",
        "countUnit": "days",
        "countNumber": 1
      },
      "action": {
        "type": "expire"
      }
    },
    {
      "action": {
        "type": "expire"
      },
      "selection": {
        "countType": "imageCountMoreThan",
        "countNumber": 50,
        "tagStatus": "tagged",
        "tagPrefixList": [
          "master-"
        ]
      },
      "description": "Expire old images with default tag",
      "rulePriority": 2
    }
  ]
}
```